### PR TITLE
fix: missing remove-markdown dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ To install this plugin, you need to add an NPM dependency to your Strapi applica
 
 ```sh
 # Using Yarn
-yarn add strapi-plugin-seo
+yarn add @strapi/plugin-seo
 
 # Or using NPM
-npm install strapi-plugin-seo
+npm install @strapi/plugin-seo
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/strapi/strapi-plugin-seo.git"
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "remove-markdown": "^0.3.0"
   },
   "author": {
     "name": "Strapi Solutions SAS",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,3 +6,8 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+remove-markdown@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/remove-markdown/-/remove-markdown-0.3.0.tgz#5e4b667493a93579728f3d52ecc1db9ca505dc98"
+  integrity sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg=


### PR DESCRIPTION
When building strapi with this plugin enabled, it errors with:

```bash
$ yarn build
ModuleNotFoundError: Module not found: Error: Can't resolve 'remove-markdown' in 'xxx/node_modules/@strapi/plugin-seo/admin/src/components/SeoChecker/utils'
```

This fix the issue by adding `remove-markdown` in package dependencies.

I also updated the package name in the README.md file.