### PR TITLE
Case sensitivity of the keywords checks

### DIFF
--- a/admin/src/components/CMEditView/RightLinksCompo/Summary/BrowserPreview/KeywordCheck/index.js
+++ b/admin/src/components/CMEditView/RightLinksCompo/Summary/BrowserPreview/KeywordCheck/index.js
@@ -10,7 +10,7 @@ import Dot from '@strapi/icons/Dot';
 
 const KeywordCheck = ({ item, keywords, label }) => {
   const _keywords = keywords.split(',');
-  const matches = _keywords.filter((x) => item.includes(x.trim()));
+  const matches = _keywords.filter((x) => item.toLowerCase().includes(x.toLowerCase().trim()));
 
   return (
     <Stack size={1} horizontal background="neutral0">

--- a/admin/src/components/CMEditView/utils/index.js
+++ b/admin/src/components/CMEditView/utils/index.js
@@ -103,6 +103,7 @@ const increaseCounter = (base, field) => {
     const wordsNotCleaned = html
       .replace(/<\/?[^>]+(>|$)/g, '')
       .replace('\n', ' ')
+      .toLowerCase()
       .split(' ');
     const words = wordsNotCleaned.filter((x) => {
       return x !== '' && x !== '\n';
@@ -187,7 +188,7 @@ const getRichTextCheck = (modifiedData, components, contentType) => {
   let wordCount = 0;
   let keywords = [];
   const tmp = _.get(modifiedData, 'seo.keywords', null);
-  if (tmp) keywords = tmp.split(',');
+  if (tmp) keywords = tmp.toLowerCase().split(',');
   keywordsDensity = {};
 
   // Iterate on every richtext fields we have


### PR DESCRIPTION
For the engines the keywords are not case sensitive. But the SEO plugin checks (and complains) if the keyword is used in the description, title or content with different  capitalization.

This PR pretends to fix that.

