### PR TITLE
feat(longtail-keywords): add support for detecting multi word substring

### DIFF
--- a/admin/src/components/CMEditView/utils/index.js
+++ b/admin/src/components/CMEditView/utils/index.js
@@ -118,9 +118,8 @@ const buildKeywordDensityObject = (keywords, words) => {
   keywords.map((keyword) => {
     if (!_.isEmpty(keyword)) {
       const trimmedKeyword = keyword.trim();
-      const count = words.filter((word) =>
-        word.includes(trimmedKeyword)
-      ).length;
+      const exp = new RegExp(trimmedKeyword, 'g');
+      const count = (words.join(' ').match(exp) || []).length;
       if (keywordsDensity[trimmedKeyword] === undefined) {
         keywordsDensity[trimmedKeyword] = { count };
       } else {


### PR DESCRIPTION
fixes #7 to support multi-word keywords

Adding this code will add support for multi-word keywords in the plugin. I have tested it in few scenarios and it is working as expected. Please let me know if something needs to be changed or improved in my implementation. I am willing to do the work for this feature.

Thank you!