### PR TITLE
Fixes wrong async useEffect usage

### DIFF
--- a/admin/src/components/CMEditView/RightLinksCompo/Summary/index.js
+++ b/admin/src/components/CMEditView/RightLinksCompo/Summary/index.js
@@ -42,27 +42,32 @@ const Summary = () => {
 
   const { contentType, components } = allLayoutData;
 
-  useEffect(async () => {
-    if (!(JSON.stringify(localChecks) === JSON.stringify(checks))) {
-      if (checks?.preview) {
-        const status = await getAllChecks(
-          layout,
-          modifiedData,
-          components,
-          contentType
-        );
-        dispatch({
-          type: 'UPDATE_FOR_PREVIEW',
-          value: status,
-        });
-      } else
-        dispatch({
-          type: 'UPDATE_FOR_PREVIEW',
-          value: checks,
-        });
-      setLocalChecks(checks);
-    }
-    setIsLoading(false);
+  useEffect(() => {
+    const fetchChecks = async () => {
+      if (!(JSON.stringify(localChecks) === JSON.stringify(checks))) {
+        if (checks?.preview) {
+          const status = await getAllChecks(
+            layout,
+            modifiedData,
+            components,
+            contentType
+          );
+          dispatch({
+            type: 'UPDATE_FOR_PREVIEW',
+            value: status,
+          });
+        } else
+          dispatch({
+            type: 'UPDATE_FOR_PREVIEW',
+            value: checks,
+          });
+        setLocalChecks(checks);
+      }
+    };
+
+    fetchChecks().then(() => {
+      setIsLoading(false);
+    });
   }, [checks]);
 
   return (

--- a/admin/src/pages/HomePage/index.js
+++ b/admin/src/pages/HomePage/index.js
@@ -39,22 +39,27 @@ const HomePage = () => {
   const contentTypes = useRef({});
 
   // Fetching the SEO component & Content-Types
-  useEffect(async () => {
-    seoComponent.current = await fetchSeoComponent();
-    contentTypes.current = await fetchContentTypes();
+  useEffect(() => {
+    const fetchData = async () => {
+      seoComponent.current = await fetchSeoComponent();
+      contentTypes.current = await fetchContentTypes();
 
-    if (!seoComponent.current) {
-      try {
-        lockAppWithAutoreload();
-        await createSeoComponent();
-      } catch (error) {
-        console.log(error);
-      } finally {
-        unlockAppWithAutoreload();
-        setShouldEffect(true);
+      if (!seoComponent.current) {
+        try {
+          lockAppWithAutoreload();
+          await createSeoComponent();
+        } catch (error) {
+          console.log(error);
+        } finally {
+          unlockAppWithAutoreload();
+          setShouldEffect(true);
+        }
       }
     }
-    setIsLoading(false);
+
+    fetchData().then(() => {
+      setIsLoading(false);
+    });
   }, [shouldEffect]);
 
   // Displaying the LoadingIndicatorPage while it fetches the data


### PR DESCRIPTION
This plugin is broken in the latest Strapi version (v4.11.0) that uses React18. The error that is triggered is caused by the wrong implementation of an async function in some useEffect hooks.

This PR implements the async useEffect properly and fixes the breaking issue with the latest Strapi version.