### PR TITLE
Fix: add `wrap=wrap` prop to `<Flex>` component

### DIFF
--- a/admin/src/components/CMEditView/RightLinksCompo/SeoChecks/KeywordDensityCheck/index.js
+++ b/admin/src/components/CMEditView/RightLinksCompo/SeoChecks/KeywordDensityCheck/index.js
@@ -76,7 +76,7 @@ const KeywordDensityCheck = ({ keywordsDensity, checks }) => {
         keywordsDensity &&
         !_.isEmpty(keywordsDensity) && (
           <Box padding={2}>
-            <Flex>
+            <Flex wrap="wrap">
               {Object.keys(keywordsDensity).map((keyword) => (
                 <Box padding={2} key={keyword}>
                   <Badge>


### PR DESCRIPTION
Closes #44 

<img width="761" alt="Screenshot 2023-06-16 at 21 42 29" src="https://github.com/strapi/strapi-plugin-seo/assets/445891/643a1131-91a3-4dd8-b8f4-403e8e03f380">
