### PR TITLE
Update node engine to use LTS versions 18 (and soon 20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     }
   ],
   "engines": {
-    "node": ">=12.x.x <=18.x.x",
+    "node": ">=18.x.x <=20.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
With Active LTS starting for v20 the 24th of October, it would be good to update the engine config in package.json. This way we won't run into an incompatibility error when install the package. Also since last September v16 is EOL and with this change the engines would align with  [strapi/strapi](https://github.com/strapi/strapi/blob/main/package.json).
 
```bash
error The engine "node" is incompatible with this module. Expected version ">=12.x.x <=18.x.x". Got "20.5.1"
error Found incompatible module.
```

Node releases info
https://nodejs.dev/en/about/releases/
![image](https://github.com/strapi/strapi-plugin-seo/assets/31662805/5fee79bd-93c6-47c0-a37d-1273bc44d7ac)


