### PR TITLE
(fix): add missing admin path for settings page links

### DIFF
--- a/admin/src/components/HomePage/Header/index.js
+++ b/admin/src/components/HomePage/Header/index.js
@@ -18,7 +18,7 @@ const Header = (seoComponent) => {
           seoComponent ? null : (
             <LinkButton
               variant="tertiary"
-              to="/plugins/content-type-builder/component-categories/shared/shared.seo"
+              to="/admin/plugins/content-type-builder/component-categories/shared/shared.seo"
               startIcon={<Pencil />}
             >
               {formatMessage({

--- a/admin/src/components/HomePage/Main/index.js
+++ b/admin/src/components/HomePage/Main/index.js
@@ -174,7 +174,7 @@ const Main = ({ contentTypes }) => {
                               <LinkButton
                                 startIcon={<Plus />}
                                 variant="secondary"
-                                href={`/plugins/content-type-builder/content-types/${item.uid}`}
+                                href={`/admin/plugins/content-type-builder/content-types/${item.uid}`}
                               >
                                 {formatMessage({
                                   id: getTrad('SEOPage.info.add'),
@@ -197,7 +197,7 @@ const Main = ({ contentTypes }) => {
                         })}
                         action={
                           <LinkButton
-                            to="/plugins/content-type-builder"
+                            to="/admin/plugins/content-type-builder"
                             variant="secondary"
                             startIcon={<Plus />}
                           >
@@ -249,7 +249,7 @@ const Main = ({ contentTypes }) => {
                               <LinkButton
                                 startIcon={<Plus />}
                                 variant="secondary"
-                                href={`/plugins/content-type-builder/content-types/${item.uid}`}
+                                href={`/admin/plugins/content-type-builder/content-types/${item.uid}`}
                               >
                                 {formatMessage({
                                   id: getTrad('SEOPage.info.add'),


### PR DESCRIPTION
With Strapi v4.15.0 and @strapi/plugin-seo v1.9.6:
I can add a component manually in the content type builder, but when I go to any of the buttons in the settings page (see attached image) I am taken to a url like: `http://localhost:1337/plugins/content-type-builder/content-types/api::article.article`
and see: `{"data":null,"error":{"status":404,"name":"NotFoundError","message":"Not Found","details":{}}}`

<img width="1099" alt="image" src="https://github.com/strapi/strapi-plugin-seo/assets/999278/6026bd99-fb48-4a14-8cfa-e5654d2c35a8">

Adding the /admin prefix fixed this. But it should be tested with other versions in case there is a more universal way to fix this.