### PR TITLE
Fix: add admin to CTB link for collection types

### DIFF
--- a/admin/src/components/HomePage/Main/index.js
+++ b/admin/src/components/HomePage/Main/index.js
@@ -96,7 +96,7 @@ const Main = ({ contentTypes }) => {
                               <LinkButton
                                 startIcon={<Plus />}
                                 variant="secondary"
-                                href={`/plugins/content-type-builder/content-types/${item.uid}`}
+                                href={`/admin/plugins/content-type-builder/content-types/${item.uid}`}
                               >
                                 {formatMessage({
                                   id: getTrad('SEOPage.info.add'),


### PR DESCRIPTION
Clicking "add component" in the collection types tab doesn't work. It works for plugin content types and single types though, because they include `/admin/`. this PR fixes collection types by adding the admin prefix too