### PR TITLE
fix(og): fixed open graph field names

### DIFF
--- a/server/src/components/open-graph.json
+++ b/server/src/components/open-graph.json
@@ -6,28 +6,28 @@
   },
   "options": {},
   "attributes": {
-    "og:title": {
+    "ogTitle": {
       "type": "string",
       "required": true,
       "maxLength": 70
     },
-    "og:description": {
+    "ogDescription": {
       "type": "string",
       "maxLength": 200,
       "required": true
     },
-    "og:image": {
+    "ogImage": {
       "allowedTypes": [
         "images"
       ],
       "type": "media",
       "multiple": false
     },
-    "og:url": {
+    "ogUrl": {
       "type": "string",
       "required": false
     },
-    "og:type": {
+    "ogType": {
       "type": "string",
       "required": false
     }


### PR DESCRIPTION
`:` Isn't allowed character for a field when the grapqhl plugin tries to generate definitions for it. 

This makes the build of the app fail if one has both Graphql Plugin and Seo plugin and adds an seo component to some content-type. 

![Screenshot 2025-01-04 at 18 06 14](https://github.com/user-attachments/assets/61e7a123-214b-4a05-bb79-1355733a51a3)

Changing the names of the open-graphql components to not include the `:` fixes this bug.