### PR TITLE
fix(og): fixed open graph field names

### DIFF
--- a/admin/src/components/CMEditView/RightLinksCompo/SeoChecks/OpenGraphCheck/index.jsx
+++ b/admin/src/components/CMEditView/RightLinksCompo/SeoChecks/OpenGraphCheck/index.jsx
@@ -3,9 +3,6 @@ import { useIntl } from 'react-intl';
 
 import isEqual from 'lodash/isEqual';
 import isNull from 'lodash/isNull';
-import isEmpty from 'lodash/isEmpty';
-
-import { Box, Badge, Flex } from '@strapi/design-system';
 
 import { SEOAccordion } from '../SEOAccordion';
 import { SeoCheckerContext } from '../../Summary';
@@ -31,7 +28,7 @@ export const OpenGraphCheck = ({ openGraph, checks }) => {
         }),
         qualityVerdict: qualityVerdict.bad,
       };
-    } else if (!openGraph['og:title'] || !openGraph['og:description'] || !openGraph['og:image']) {
+    } else if (!openGraph['ogTitle'] || !openGraph['ogDescription'] || !openGraph['ogImage']) {
       status = {
         message: formatMessage({
           id: getTrad('SEOChecks.openGraphCheck.not-configured'),

--- a/admin/src/components/CMEditView/RightLinksCompo/Summary/OpenGraphPreview/index.jsx
+++ b/admin/src/components/CMEditView/RightLinksCompo/Summary/OpenGraphPreview/index.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Box, Flex, Typography, EmptyStateLayout, Badge, Modal } from '@strapi/design-system';
+import { Badge, Box, EmptyStateLayout, Flex, Modal, Typography } from '@strapi/design-system';
 
 import { Illo } from '../../../../HomePage/Main/EmptyComponentLayout/illo';
 
@@ -26,7 +26,7 @@ export const OpenGraphPreview = ({ modifiedData }) => {
         </Typography>
       </Modal.Header>
       <Modal.Body>
-        {openGraph['og:title'] && openGraph['og:description'] && openGraph['og:image'] ? (
+        {openGraph['ogTitle'] && openGraph['ogDescription'] && openGraph['ogImage'] ? (
           <>
             <Flex alignItems="left" direction="column" gap={2}>
               <Flex gap={1}>
@@ -36,9 +36,9 @@ export const OpenGraphPreview = ({ modifiedData }) => {
               </Flex>
             </Flex>
             <FacebookOGPreview
-              title={openGraph['og:title']}
-              description={openGraph['og:description']}
-              image={openGraph['og:image']}
+              title={openGraph['ogTitle']}
+              description={openGraph['ogDescription']}
+              image={openGraph['ogImage']}
             />
             <Flex alignItems="left" direction="column" gap={2}>
               <Flex gap={1}>
@@ -48,9 +48,9 @@ export const OpenGraphPreview = ({ modifiedData }) => {
               </Flex>
             </Flex>
             <TwitterOGPreview
-              title={openGraph['og:title']}
-              description={openGraph['og:description']}
-              image={openGraph['og:image']}
+              title={openGraph['ogTitle']}
+              description={openGraph['ogDescription']}
+              image={openGraph['ogImage']}
             />
             <Flex alignItems="left" direction="column" gap={2}>
               <Flex gap={1}>
@@ -60,9 +60,9 @@ export const OpenGraphPreview = ({ modifiedData }) => {
               </Flex>
             </Flex>
             <LinkedInOGPreview
-              title={openGraph['og:title']}
-              description={openGraph['og:description']}
-              image={openGraph['og:image']}
+              title={openGraph['ogTitle']}
+              description={openGraph['ogDescription']}
+              image={openGraph['ogImage']}
             />
           </>
         ) : (

--- a/admin/src/components/CMEditView/utils/checks.js
+++ b/admin/src/components/CMEditView/utils/checks.js
@@ -208,7 +208,7 @@ export const openGraphPreview = (modifiedData) => {
       qualityVerdict: qualityVerdict.bad,
     };
     return status;
-  } else if (!openGraph['og:title'] || !openGraph['og:description'] || !openGraph['og:image']) {
+  } else if (!openGraph['ogTitle'] || !openGraph['ogDescription'] || !openGraph['ogImage']) {
     status = {
       message: '',
       qualityVerdict: qualityVerdict.improvements,

--- a/server/src/components/open-graph.json
+++ b/server/src/components/open-graph.json
@@ -6,28 +6,28 @@
   },
   "options": {},
   "attributes": {
-    "og:title": {
+    "ogTitle": {
       "type": "string",
       "required": true,
       "maxLength": 70
     },
-    "og:description": {
+    "ogDescription": {
       "type": "string",
       "maxLength": 200,
       "required": true
     },
-    "og:image": {
+    "ogImage": {
       "allowedTypes": [
         "images"
       ],
       "type": "media",
       "multiple": false
     },
-    "og:url": {
+    "ogUrl": {
       "type": "string",
       "required": false
     },
-    "og:type": {
+    "ogType": {
       "type": "string",
       "required": false
     }


### PR DESCRIPTION
## Summary

The : character is not allowed in field names when the GraphQL plugin generates type definitions. This restriction causes the app build to fail when both the GraphQL plugin and the SEO plugin are used, specifically when an SEO component is added to a content type.

## Changes

- Updated the naming of Open Graph fields in the SEO plugin to remove the : character, resolving the build failure.
- Ensured compatibility between the GraphQL and SEO plugins, including fixing the issue where the preview functionality in the admin panel stopped working.

## Screenshots
- Attached a screenshot illustrating the build error:

![Screenshot 2025-01-04 at 18 06 14](https://github.com/user-attachments/assets/7017244f-4442-4e0a-ac83-f283c92cefb4)

- Working preview with the new attribute names:

![Screenshot 2025-01-04 at 20 02 42](https://github.com/user-attachments/assets/b66841a7-b91b-4c84-956c-c1b1561ceb28)

## Related Issues

This PR addresses the issues raised in:
- #92
- #93

Both issues suggest renaming attributes as a potential solution but also note that the preview feature in the admin panel stops working. This PR resolves both the build failure and the preview functionality issue.

## Testing
- Verified that builds now complete successfully with both plugins enabled.
- Confirmed that the preview functionality in the admin panel works as expected.