### PR TITLE
fix(admin): mount SEO panel via addEditViewSidePanel on Strapi 5

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Search } from '@strapi/icons';
 
 import pluginPkg from '../../package.json';
@@ -30,7 +32,23 @@ export default {
     });
   },
   bootstrap(app) {
-    app.getPlugin('content-manager').injectComponent('editView', 'right-links', {
+    const cm = app.getPlugin('content-manager');
+    const addEditViewSidePanel = cm?.apis?.addEditViewSidePanel;
+
+    // Strapi 5 exposes a first-class side-panel API. Use it so the SEO summary
+    // renders as a proper panel in the edit-view panel stack instead of the
+    // legacy `right-links` injection zone, which mounts below every panel and
+    // looks visually detached. Append it last so it sits under "Information".
+    if (typeof addEditViewSidePanel === 'function') {
+      const SeoSidePanel = () => ({
+        title: 'SEO',
+        content: React.createElement(SeoChecker),
+      });
+      addEditViewSidePanel((panels) => [...panels, SeoSidePanel]);
+      return;
+    }
+
+    cm.injectComponent('editView', 'right-links', {
       name: 'SeoChecker',
       Component: SeoChecker,
     });


### PR DESCRIPTION
## Problem

On Strapi 5 the SEO summary is injected through the legacy
`app.getPlugin('content-manager').injectComponent('editView', 'right-links', …)`
zone. That slot renders **below** every first-class edit-view side panel
(Information, Releases, …), so the SEO panel looks visually detached from the
panel stack rather than being part of it.

## Fix

Strapi 5 exposes a first-class side-panel API. When
`contentManager.apis.addEditViewSidePanel` is available, register the SEO
summary as a real side panel, appended **after** the existing panels so it
sits under "Information". When the API is not present (older hosts), fall back
to the existing `right-links` injection — no behaviour change there.

```js
const cm = app.getPlugin('content-manager');
const addEditViewSidePanel = cm?.apis?.addEditViewSidePanel;
if (typeof addEditViewSidePanel === 'function') {
  const SeoSidePanel = () => ({ title: 'SEO', content: React.createElement(SeoChecker) });
  addEditViewSidePanel((panels) => [...panels, SeoSidePanel]);
  return;
}
cm.injectComponent('editView', 'right-links', { name: 'SeoChecker', Component: SeoChecker });
```

## Notes

- Backwards compatible via the runtime feature check; no peer-dep bump needed.
- `npm run build` passes.