### PR TITLE
fix: resolve pluginId correctly for non-@strapi scoped packages

### DIFF
--- a/admin/src/pluginId.js
+++ b/admin/src/pluginId.js
@@ -1,3 +1,3 @@
 import pluginPkg from '../../package.json';
 
-export const pluginId = pluginPkg.name.replace(/^@strapi\/plugin-/i, '');
+export const pluginId = pluginPkg.name.replace(/^@.*\/(?:strapi-plugin-)?/, '');


### PR DESCRIPTION
## Problem

When the plugin is installed, the admin panel crashes with:

```
TypeError: Cannot read properties of null (reading 'collectionTypes')
    at Main (...)
```

This happens because `pluginId` is derived using:

```js
export const pluginId = pluginPkg.name.replace(/^@strapi\/plugin-/i, '');
```

The regex only strips the `@strapi/plugin-` prefix. Since this package is scoped under `@notum-cz/`, the replacement never matches and `pluginId` ends up as the full package name: `@notum-cz/strapi-plugin-seo`.

The admin frontend then calls `/@notum-cz/strapi-plugin-seo/content-types`, which returns 404. The `fetchContentTypes` function catches the error and returns `null`, causing the `Main` component to crash when it reads `null.collectionTypes`.

## Root cause

The server registers plugin routes under the short plugin name (`seo`), but the admin frontend builds API URLs using the unstripped `pluginId`, creating a mismatch between the expected and actual route paths.

## Fix

Update the regex to handle any npm scope, not just `@strapi/`:

```js
export const pluginId = pluginPkg.name.replace(/^@.*\/(?:strapi-plugin-)?/, '');
```

This correctly resolves `@notum-cz/strapi-plugin-seo` → `seo`, matching the route prefix the server registers.

## Verification

- Reproduced on Strapi v5.47.1 with `@notum-cz/strapi-plugin-seo@2.0.12`
- After the fix, the admin calls `/seo/content-types` and the plugin loads correctly